### PR TITLE
remove CSP report-uri requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,12 @@ Logging
 
 Web Applications
 ----------------
-* [ ] Must have a CSP with
-  * [ ] a report-uri pointing to the service's own `/__cspreport__` endpoint
-  * [ ] web API responses should return `default-src 'none'; frame-ancestors 'none'; base-uri 'none'; report-uri /__cspreport__` to disallowing all content rendering, framing, and report violations
-  * [ ] if default-src is not `none`, frame-src, and object-src should be `none` or only allow specific origins
-  * [ ] no use of unsafe-inline or unsafe-eval in script-src, style-src, and img-src
+* [ ] Must have a [Content Security Policy (CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy). The policy:
+  * [ ] should set `default-src none` or only allow specific origins and set `frame-src` and `object-src` to `none` if default-src is not `none`
+  * [ ] web API responses should return `default-src 'none'; frame-ancestors 'none'; base-uri 'none'` to disallow content rendering and framing/redressing
+  * [ ] should not use `unsafe-inline` or `unsafe-eval` in `script-src`, `style-src`, or `img-src` directives (
+  * [ ] may include a `report-uri` directive to provide visibility into CSP violations
+
 * [ ] Third-party javascript must be pinned to specific versions using [Subresource Integrity (SRI)](https://infosec.mozilla.org/guidelines/web_security#subresource-integrity)
 * [ ] Web APIs:
   * [ ] must set a non-HTML content-type on all responses, including 300s, 400s and 500s


### PR DESCRIPTION
Changes:
* drop `  * [ ] a report-uri pointing to the service's own `/__cspreport__` endpoint`
* fix typo `to disallowing` -> `to disallow`
* remove `report-uri` from the example web API CSP

Refs https://github.com/mozilla/concepts/issues/27 which we discussed in the SecOps team meeting where and concluded:

* CSP reports are useful for audit logs and fraud detection and we still recommend them for high value apps and services
* for static and other sites, capturing the reports doesn't make the CSP any more effective in terms of preventing XSS, clickjacking, infoleak, etc. (and can represent a privacy leak when improperly set)
* teams should:
  * catch CSP errors in dev and QA before deploying
  * if they want to capture CSP reports like stacktraces 

r? @jvehent