### PR TITLE
Require frame-ancestors 'none' on admin panels

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Infrastructure
 * If service has an admin panels, it must:
   * [ ] only be available behind Mozilla VPN (which provides MFA)
   * [ ] require Auth0 authentication
-  * [ ] Enforce a CSP with `frame-ancestors 'none';` to prevent iframe related attacks
+  * [ ] Enforce a CSP with `frame-ancestors 'none'` to prevent iframe related attacks, such as [DOM-Based CSRF](https://www.youtube.com/watch?v=Femsrx0m9bU)
 
 Development
 -----------

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Infrastructure
 * If service has an admin panels, it must:
   * [ ] only be available behind Mozilla VPN (which provides MFA)
   * [ ] require Auth0 authentication
+  * [ ] Enforce a CSP with `frame-ancestors 'none';` to prevent iframe related attacks
 
 Development
 -----------


### PR DESCRIPTION
This came up during a discussion with @gdestuynder and seems good practice for admin panels anyway. Thoughts?